### PR TITLE
解除前端的图片大小限制

### DIFF
--- a/wwwroot/assets/photos/js/photos.js
+++ b/wwwroot/assets/photos/js/photos.js
@@ -129,9 +129,9 @@ var methods = {
       return false;
     }
 
-    var isLt10M = file.size / 1024 / 1024 < 10;
-    if (!isLt10M) {
-      utils.error('上传图片大小不能超过 10MB!');
+    var isLt1024M = file.size / 1024 / 1024 < 1024;
+    if (!isLt1024M) {
+      utils.error('上传图片大小不能超过 1024 MB!');
       return false;
     }
     return true;


### PR DESCRIPTION
是否应该在网站的上传设置中统一控制图片的上传大小呢？

目前，发现在前端代码中，默认设置了图片上传的大小为10MB。如果想上传大于10MB的图片，则会导致上传失败。

因此，将前端的大小限制设置为1024MB（表示无限制）。

然后，最终是否可以上传图片的判断交给后端API进行处理。